### PR TITLE
Add library_name to all upload models

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1,7 +1,12 @@
 import torch
 from huggingface_hub import PyTorchModelHubMixin
 
-class QFilters(torch.nn.Module, PyTorchModelHubMixin):
+class QFilters(
+    torch.nn.Module,
+    PyTorchModelHubMixin,
+    library_name="q-filter",
+    repo_url="https://github.com/NathanGodey/qfilters",
+):
     def __init__(self, num_layers, num_kv_heads, kv_head_dim):
         super().__init__()
         self.q_filters = torch.nn.Parameter(torch.randn(num_layers, num_kv_heads, kv_head_dim))


### PR DESCRIPTION
Related to https://github.com/NathanGodey/qfilters/issues/1

If you'd like, it's also possible to add attributes like `tags`, `license`, `pipeline_tag`, etc. The goal is that **every** model pushed to the Hub using your library will be correctly labelled and therefore easier to find for users. Typically models will be discoverable in https://huggingface.co/models?other=q-filter